### PR TITLE
Added Search Mode

### DIFF
--- a/js/Client/source.js
+++ b/js/Client/source.js
@@ -8,6 +8,7 @@ var g_prevLiveGames;
 var g_mode;
 var g_updateTimeout;
 var g_bmacAnimating;
+var searchSelectedGameId;
 
 var MAX_HUE = 240.0;
 var COLORBLIND_START_R = 75.0;
@@ -20,6 +21,7 @@ var COLORBLIND_END_B = 50.0;
 var MODE_COUNT = "count";
 var MODE_FIRST_GAME = "firstGame";
 var MODE_LAST_GAME = "lastGame";
+var MODE_SEARCH = "search"
 
 var GROUP_ALL = "all";
 var GROUP_ONGOING = "ongoing";
@@ -331,14 +333,22 @@ function changeMode() {
 
 	switch (g_mode) {
 		case MODE_FIRST_GAME:
+			deselectSearchedGame();
+			hideSearch();
 			showSlider();
+			break;
+		case MODE_SEARCH:
+			hideSlider();
+			showSearch();
 			break;
 		case MODE_LAST_GAME:
 		/* falls through */
 		case MODE_COUNT:
 		/* falls through */
 		default:
+			deselectSearchedGame();
 			hideSlider();
+			hideSearch();
 			break;
 	}
 
@@ -430,6 +440,20 @@ function changeYearSlider() {
 		}
 	}
 
+}
+
+function showSearch() {
+	var searchContainer = document.getElementById("searchContainer");
+	if (searchContainer) {
+		searchContainer.classList.remove("invisible");
+	}
+}
+
+function hideSearch() {
+	var searchContainer = document.getElementById("searchContainer");
+	if (searchContainer) {
+		searchContainer.classList.add("invisible");
+	}
 }
 
 //shades the cells based on the number of times that score has been achieved
@@ -1328,4 +1352,56 @@ function mouseOffDelegate(i, j) {
 	return function () {
 		mouseOff(i, j);
 	};
+}
+
+function onScoreSearchChange() {
+	if (searchSelectedGameId) {
+		var cell = document.getElementById(searchSelectedGameId);
+		if (cell) {
+			cell.classList.remove("hover");
+			cell.classList.remove("selected");
+		}
+	}
+	var searchClearButton = document.getElementById("scoreSearchClearButton");
+	var homeScore = document.getElementById("score1SearchInput").value;
+	var awayScore = document.getElementById("score2SearchInput").value;
+	if (homeScore && awayScore) {
+		var highScore = (awayScore > homeScore ? awayScore : homeScore);
+		var lowScore = (awayScore > homeScore ? homeScore : awayScore);
+		searchSelectedGameId = "cell_" + lowScore + "-" + highScore;
+		var cell = document.getElementById(searchSelectedGameId);
+		if (cell) {
+			cell.classList.add("hover")
+			cell.classList.add("selected");
+		}
+		if (searchClearButton && searchClearButton.classList.contains("invisible")) {
+			searchClearButton.classList.remove("invisible");
+		}
+	}
+	else {
+		if (searchClearButton && !searchClearButton.classList.contains("invisible")) {
+			searchClearButton.classList.add("invisible");
+		}
+	}
+}
+
+function deselectSearchedGame() {
+	var searchClearButton = document.getElementById("scoreSearchClearButton");
+	if (searchSelectedGameId) {
+		var cell = document.getElementById(searchSelectedGameId);
+		if (cell) {
+			cell.classList.remove("hover");
+			cell.classList.remove("selected");
+		}
+	}
+	searchSelectedGameId = null;
+	document.getElementById("score1SearchInput").value = "";
+	document.getElementById("score2SearchInput").value = "";
+	if (searchClearButton && !searchClearButton.classList.contains("invisible")) {
+		searchClearButton.classList.add("invisible");
+	}
+}
+
+function onScoreSearchClear() {
+	deselectSearchedGame();
 }

--- a/styles/common.css
+++ b/styles/common.css
@@ -280,11 +280,11 @@ footer a {
 }
 
 .hidden {
-	display: none;
+	display: none !important;
 }
 
 .invisible {
-	visibility: hidden;
+	display: none !important;
 }
 
 #bmac {
@@ -292,4 +292,33 @@ footer a {
 	right: 5;
 	bottom: 5;
 	z-index: 1;
+}
+
+.scoreSearchInputWrapper {
+	display: flex;
+	flex-direction: column;
+	padding-bottom: 20px;
+	padding-top: 20px;
+}
+
+.searchContainer {
+	flex-direction: row;
+	justify-content: center;
+	align-items: center;
+}
+
+#scoreSearchClearButton {
+	margin-left: 5px;
+	margin-top: 2px;
+}
+
+.score1SearchText, .score2SearchText {
+	position: relative;
+	display: inline-block;
+	padding-left: 2px;
+	width: 60px;
+}
+
+#score1SearchInput, #score2SearchInput {
+	width: 50px;
 }

--- a/styles/table.css
+++ b/styles/table.css
@@ -9,6 +9,7 @@ body {
 	text-align: center;
 	width: 1140px;
 	overflow-x: auto;
+	margin-top: 20px;
 }
 
 .select {

--- a/view/index.html
+++ b/view/index.html
@@ -64,12 +64,26 @@
 					<option value="count">Count</option>
 					<option value="firstGame">First Game</option>
 					<option value="lastGame">Latest Game</option>
+					<option value="search">Search</option>
 				</select>
 			</div>
 		</div>
 		<div id="sliderContainer" class="sectionContainer invisible">
 			<input type="range" min="1920" max="" value="" class="slider" id="yearSlider">
 			<span id="sliderValue"></span>
+		</div>
+		<div id="searchContainer" class="searchContainer invisible">
+			<div class="scoreSearchInputWrapper">
+				<div class="score1SearchWrapper">
+					<div class="score1SearchText">Score 1:</div>
+					<input type="number" id="score1SearchInput" oninput="onScoreSearchChange()">
+				</div>
+				<div class="score2SearchWrapper">
+					<div class="score2SearchText">Score 2:</div>
+					<input type="number" id="score2SearchInput" oninput="onScoreSearchChange()">
+				</div>
+				<button type="button" class="invisible" id="scoreSearchClearButton" onclick="onScoreSearchClear()">Clear</button>
+			</div>
 		</div>
 		<div id="tableContainer" class="sectionContainer">
 			<div id="loadingTableDiv">


### PR DESCRIPTION
I decided to add a "search" mode to the "mode" selector.

This update helps out especially on mobile devices for times that you want to lookup a specific score to see if there has been scorigami. However, since mobile screens are so small, it's nearly impossible to find a specific score since the table axes don't show at the same time (something else I'm looking to possibly fix in the future).

I also noticed the use of the "invisible" class, which seems a bit weird to me. This class ends up leaving a bunch of extra whitespace that should probably be created using normal margin based styling. I modified this class to change the display type of whatever elements the class applies to to "hidden". This allowed me to reuse the whitespace at the top of the page for the score search text boxes.

